### PR TITLE
Improve mathtext sanitization and add regression tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 build/
 dist/
 *.spec
+!latexclip.spec
 __pycache__/
 *.pyc
 *.pyo

--- a/README.md
+++ b/README.md
@@ -33,8 +33,10 @@ If you don't have Python, you need to install it first.
     ```
 3.  Install the necessary Python libraries by running this command:
     ```cmd
-    pip install pillow matplotlib pywin32
+    pip install pillow matplotlib ttkthemes pywin32
     ```
+    *On non-Windows systems the `pywin32` dependency is optional and can be
+    omitted.*
 
 ### Step 4: Run the Application
 
@@ -89,8 +91,11 @@ pip install pyinstaller
 
 In the Command Prompt, navigate to the tool's directory and run the following command:
 
+Use the bundled spec file so PyInstaller collects the themed assets and
+matplotlib backends automatically:
+
 ```cmd
-pyinstaller --noconsole --onefile latexclip.py
+pyinstaller latexclip.spec
 ```
 
 After a few moments, you will find a `dist` folder. Inside, `latexclip.exe` is your standalone application. You can move this file anywhere on your computer or create a shortcut to it on your desktop.

--- a/latexclip.py
+++ b/latexclip.py
@@ -80,6 +80,13 @@ def sanitize_for_mathtext(s: str) -> str:
     if text.startswith(r"\[") and text.endswith(r"\]"):
         text = text[2:-2].strip()
     already_math = text.startswith("$") and text.endswith("$")
+
+    def escape_literals(segment: str) -> str:
+        """Escape characters that would otherwise break mathtext rendering."""
+        # Escape TeX special characters that commonly appear in plain text.
+        return re.sub(r"(?<!\\)([%&#$])", r"\\\1", segment)
+
+    text = escape_literals(text)
     def to_rm(m):
         return r"\mathrm{" + m.group(1) + "}"
     text = re.sub(r"\\text\{([^}]*)\}", to_rm, text)

--- a/latexclip.spec
+++ b/latexclip.spec
@@ -1,0 +1,60 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+from PyInstaller.utils.hooks import collect_data_files
+
+block_cipher = None
+
+hiddenimports = [
+    "PIL._tkinter_finder",
+    "matplotlib.backends.backend_tkagg",
+]
+
+datas = collect_data_files("ttkthemes")
+
+
+a = Analysis(
+    ['latexclip.py'],
+    pathex=[],
+    binaries=[],
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='latexclip',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=False,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='latexclip',
+)

--- a/tests/test_plaintext.py
+++ b/tests/test_plaintext.py
@@ -1,0 +1,105 @@
+"""Regression tests for the LaTeX to plain-text helpers."""
+
+from __future__ import annotations
+
+import sys
+import types
+from importlib import util
+from pathlib import Path
+
+import pytest
+
+
+def _install_test_stubs(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Provide lightweight shims for optional runtime dependencies."""
+
+    # ttkthemes is only required for the GUI, so a simple placeholder works.
+    themed_module = types.ModuleType("ttkthemes")
+    themed_module.ThemedTk = type("DummyThemedTk", (), {})
+    monkeypatch.setitem(sys.modules, "ttkthemes", themed_module)
+
+    # Pillow stubs that satisfy the module-level imports without shipping the
+    # heavyweight dependency in the test environment.
+    pil_module = types.ModuleType("PIL")
+    pil_image = types.ModuleType("PIL.Image")
+    pil_image.MAX_IMAGE_PIXELS = None
+    pil_image.LANCZOS = 1
+
+    def _unavailable(*_args, **_kwargs):  # pragma: no cover - defensive helper
+        raise RuntimeError("Image operations are not available in tests.")
+
+    pil_image.open = _unavailable
+    pil_imagetk = types.ModuleType("PIL.ImageTk")
+    pil_module.Image = pil_image
+    pil_module.ImageTk = pil_imagetk
+    monkeypatch.setitem(sys.modules, "PIL", pil_module)
+    monkeypatch.setitem(sys.modules, "PIL.Image", pil_image)
+    monkeypatch.setitem(sys.modules, "PIL.ImageTk", pil_imagetk)
+
+    # Matplotlib shims that keep rcParams available and provide inert pyplot
+    # helpers so module import succeeds.
+    mpl_module = types.ModuleType("matplotlib")
+    mpl_module.rcParams = {}
+    mpl_module.use = lambda _backend: None
+
+    pyplot = types.ModuleType("matplotlib.pyplot")
+
+    class _DummyFigure:
+        def __init__(self) -> None:
+            self.patch = types.SimpleNamespace(set_alpha=lambda *_a, **_k: None)
+
+        def add_axes(self, _rect):
+            return types.SimpleNamespace(
+                axis=lambda *_a, **_k: None,
+                text=lambda *_a, **_k: None,
+            )
+
+    pyplot.figure = lambda *_a, **_k: _DummyFigure()
+    pyplot.savefig = lambda *_a, **_k: None
+    pyplot.close = lambda *_a, **_k: None
+    mpl_module.pyplot = pyplot
+    monkeypatch.setitem(sys.modules, "matplotlib", mpl_module)
+    monkeypatch.setitem(sys.modules, "matplotlib.pyplot", pyplot)
+
+
+@pytest.fixture
+def latexclip(monkeypatch: pytest.MonkeyPatch):
+    """Import the module under test with lightweight dependency shims."""
+
+    # Ensure a clean import each time the fixture initialises.
+    sys.modules.pop("latexclip", None)
+    _install_test_stubs(monkeypatch)
+
+    spec = util.spec_from_file_location("latexclip", Path(__file__).resolve().parent.parent / "latexclip.py")
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive guard
+        raise RuntimeError("Unable to load latexclip module for testing.")
+
+    module = util.module_from_spec(spec)
+    sys.modules["latexclip"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_plaintext_preserves_nested_fractions(latexclip):
+    result = latexclip.latex_to_plaintext(r"\frac{1+\frac{1}{x}}{y}")
+    assert result == r"\frac(1+(1)/(x))(y)"
+
+
+def test_plaintext_handles_nested_sqrt(latexclip):
+    result = latexclip.latex_to_plaintext(r"\sqrt{\frac{a}{b}}")
+    assert result == r"sqrt(\frac(a)(b))"
+
+
+def test_plaintext_expands_text_blocks(latexclip):
+    result = latexclip.latex_to_plaintext(r"\text{Area} = \frac{1}{2} b h")
+    assert result == "Area = (1)/(2) b h"
+
+
+def test_sanitizer_escapes_plain_text_specials(latexclip):
+    result = latexclip.sanitize_for_mathtext("Save 50% & more #1")
+    assert result == r"$Save 50\% \& more \#1$"
+
+
+def test_sanitizer_retains_existing_escapes(latexclip):
+    result = latexclip.sanitize_for_mathtext(r"Already escaped \% value")
+    assert result == r"$Already escaped \% value$"


### PR DESCRIPTION
## Summary
- escape mathtext special characters so plain text renders reliably in the mathtext renderer
- add a PyInstaller spec that bundles ttkthemes data and document the updated dependency list
- introduce regression tests for the plain-text converter and sanitizer with lightweight stubs for optional GUI dependencies

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd5e01e8c48321a9029ca23c0bebb9