### PR TITLE
Adjust README license wording

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -93,3 +93,25 @@ Si prefieres abrir la herramienta sin usar la terminal, puedes generar un ejecut
 ---
 
 ¿Listo para compartir tus notas? Copia tus fórmulas desde ChatGPT, pega en LaTeX Clip y obtén imágenes nítidas o marcado listo para tus documentos profesionales.
+
+---
+
+## Licencia
+
+Copyright (c) 2024 colaboradores de LaTeX Clip
+
+Por la presente se concede permiso, libre de cargos, a cualquier persona que obtenga una copia
+de este software y de los archivos de documentación asociados (el "Software"), para operar con
+el Software sin restricción, incluyendo sin limitación los derechos a usar, copiar, modificar,
+fusionar, publicar y distribuir copias del Software, y a permitir que las personas a las que se
+les proporcione el Software lo hagan, sujeto a las siguientes condiciones:
+
+El aviso de copyright anterior y este aviso de permiso deberán incluirse en todas las copias o
+partes sustanciales del Software.
+
+EL SOFTWARE SE PROPORCIONA "TAL CUAL", SIN GARANTÍA DE NINGÚN TIPO, EXPRESA O IMPLÍCITA,
+INCLUYENDO PERO NO LIMITADO A LAS GARANTÍAS DE COMERCIALIZACIÓN, IDONEIDAD PARA UN PROPÓSITO
+PARTICULAR E INCUMPLIMIENTO. EN NINGÚN CASO LOS AUTORES O LOS TITULARES DEL COPYRIGHT SERÁN
+RESPONSABLES DE NINGUNA RECLAMACIÓN, DAÑO O OTRA RESPONSABILIDAD, YA SEA EN UNA ACCIÓN DE
+CONTRATO, AGRAVIO O CUALQUIER OTRA FIGURA, QUE SURJA DE, O EN CONEXIÓN CON EL SOFTWARE O SU
+USO U OTROS TRATOS EN EL SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -132,3 +132,27 @@ python -m PyInstaller --noconsole --onefile "latexclip.py"
 ```
 
 After a few moments, you will find a `dist` folder. Inside, `latexclip.exe` is your standalone application. You can move this file anywhere on your computer or create a shortcut to it on your desktop.
+
+---
+
+## License
+
+Copyright (c) 2024 LaTeX Clip contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to the
+following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary
- remove the "sublicense, and/or sell" wording from the README's MIT License section

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e7ac057e1c832191a6eeabc7fe754d